### PR TITLE
fix: mongodb connectionurl parse options

### DIFF
--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -134,12 +134,27 @@ export class DriverUtils {
         let port = undefined;
         let hostReplicaSet = undefined;
         let replicaSet = undefined;
-        // remove mongodb query params
-        if (afterBase && afterBase.indexOf("?") !== -1) {
-            // split params to get replica set
-            afterQuestionMark = afterBase.substr((afterBase.indexOf("?") + 1), afterBase.length);
-            replicaSet = afterQuestionMark.split("=")[1];
+        
+        let optionsObject: any = {};
 
+        if (afterBase && afterBase.indexOf("?") !== -1) {
+
+            // split params
+            afterQuestionMark = afterBase.substr((afterBase.indexOf("?") + 1), afterBase.length);
+
+            const optionsList = afterQuestionMark.split("&");
+            let optionKey: string;
+            let optionValue: string;
+
+            // create optionsObject for merge with connectionUrl object before return
+            optionsList.forEach(optionItem => {
+                optionKey = optionItem.split("=")[0];
+                optionValue = optionItem.split("=")[1];
+                optionsObject[optionKey] = optionValue;
+            });
+
+            // specific replicaSet value to set options about hostReplicaSet
+            replicaSet = optionsObject["replicaSet"];
             afterBase = afterBase.substr(0, afterBase.indexOf("?"));
         }
 
@@ -155,21 +170,28 @@ export class DriverUtils {
             password = usernameAndPassword.substr(firstColon + 1);
         }
 
+        // If replicaSet have value set It as hostlist, If not set like standalone host
         if (replicaSet) {
             hostReplicaSet = hostAndPort;
         } else {
             [host, port] = hostAndPort.split(":");
         }
 
-        return {
+        let connectionUrl: any = {
             type: type,
             host: host,
             hostReplicaSet: hostReplicaSet,
             username: decodeURIComponent(username),
             password: decodeURIComponent(password),
             port: port ? parseInt(port) : undefined,
-            database: afterBase || undefined,
-            replicaSet: replicaSet || undefined
+            database: afterBase || undefined
         };
+
+        // Loop to set every options in connectionUrl to object
+        for (const [key, value] of Object.entries(optionsObject)) {
+            connectionUrl[key] = value
+        }
+
+        return connectionUrl;
     }
 }

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -189,7 +189,7 @@ export class DriverUtils {
 
         // Loop to set every options in connectionUrl to object
         for (const [key, value] of Object.entries(optionsObject)) {
-            connectionUrl[key] = value
+            connectionUrl[key] = value;
         }
 
         return connectionUrl;

--- a/test/github-issues/7401/issue-7401.ts
+++ b/test/github-issues/7401/issue-7401.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+import { DriverUtils } from "../../../src/driver/DriverUtils"
+import { expect } from "chai";
+
+describe("github issues > #7401 MongoDB replica set connection string not support with method \"parseConnectionUrl\" & \"buildConnectionUrl\"", () => {
+
+    it("should parse replicaSet and host list in ConnectionUrl", () => {
+
+       var options = DriverUtils.buildMongoDBDriverOptions({url: "mongodb://testuser:testpwd@test-primary.example.com:27017,test-secondary-1.example.com:27017,test-secondary-2.example.com:27017/testdb?replicaSet=testreplicaset"})
+
+       expect((options.hostReplicaSet ? options.hostReplicaSet as string : '')).to.equal('test-primary.example.com:27017,test-secondary-1.example.com:27017,test-secondary-2.example.com:27017');
+       expect((options.username ? options.username as string : '')).to.equal('testuser');
+       expect((options.password ? options.password as string : '')).to.equal('testpwd');
+       expect((options.database ? options.database as string : '')).to.equal('testdb');
+       expect((options.replicaSet ? options.replicaSet as string : '')).to.equal('testreplicaset');
+    });
+
+});

--- a/test/github-issues/7437/issue-7437.ts
+++ b/test/github-issues/7437/issue-7437.ts
@@ -1,0 +1,22 @@
+import "reflect-metadata";
+import { DriverUtils } from "../../../src/driver/DriverUtils"
+import { expect } from "chai";
+
+describe("github issues > #7437 MongoDB options never parse in connectionUrl and after my fix was parse incorrect", () => {
+
+    it("should parse options in ConnectionUrl", () => {
+
+       var options = DriverUtils.buildMongoDBDriverOptions({url: "mongodb://testuser:testpwd@test-primary.example.com:27017/testdb?retryWrites=true&w=majority&useUnifiedTopology=true"})
+
+       expect((options.host ? options.host as string : '')).to.equal('test-primary.example.com');
+       expect((options.username ? options.username as string : '')).to.equal('testuser');
+       expect((options.password ? options.password as string : '')).to.equal('testpwd');
+       expect((options.port ? options.port as number : 0)).to.equal(27017);
+       expect((options.database ? options.database as string : '')).to.equal('testdb');
+
+       expect((options.retryWrites ? options.retryWrites as string : '')).to.equal('true');
+       expect((options.w ? options.w as string : '')).to.equal('majority');
+       expect((options.useUnifiedTopology ? options.useUnifiedTopology as string : '')).to.equal('true');
+    });
+
+});


### PR DESCRIPTION
- Loop every options in mongodb connection url and turn it as object to merge with connection url object before return of method "parseMongoDBConnectionUrl"
- unit test of mongodb replicaset parse connectionurl of #7401
- unit test of mongodb options parse connectionurl of #7437


### Description of change

## src\driver\DriverUtils.ts
```
const optionsList = afterQuestionMark.split("&");
let optionKey: string;
let optionValue: string;

optionsList.forEach(optionItem => {
    optionKey = optionItem.split("=")[0];
    optionValue = optionItem.split("=")[1];
    optionsObject[optionKey] = optionValue;
});
```
Loop to create option object **"optionsObject"**. Example, with connection string below
```
mongodb://testuser:testpwd@test-primary.example.com:27017/testdb?retryWrites=true&w=majority&useUnifiedTopology=true
```
It'll turn options to 
```
{
    retryWrites: 'true',
    w: 'majority',
    useUnifiedTopology: 'true'
}
```

After that It use **"optionsObject"** to merge with **"connectionUrl"** before return as code below.
```
let connectionUrl: any = {
    type: type,
    host: host,
    hostReplicaSet: hostReplicaSet,
    username: decodeURIComponent(username),
    password: decodeURIComponent(password),
    port: port ? parseInt(port) : undefined,
    database: afterBase || undefined
};

for (const [key, value] of Object.entries(optionsObject)) {
    connectionUrl[key] = value
}

return connectionUrl;
```


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as Fixes [#7437](https://github.com/typeorm/typeorm/issues/7437)
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)